### PR TITLE
Align SMB nmap script list

### DIFF
--- a/jobs/07_service_checks.sh
+++ b/jobs/07_service_checks.sh
@@ -50,7 +50,7 @@ fi
 ################################
 SMB_HOSTS="$(hosts_for_port 445 || true)"
 if [[ -n "$SMB_HOSTS" ]]; then
-  echo "[*] nmap smb2-security-mode,smb-os-discovery"
+  echo "[*] nmap smb2-security-mode,smb2-time,smb-os-discovery,smb2-capabilities"
   : > "$OUT/services/smb_info.txt"
   echo $SMB_HOSTS | tr ' ' '\n' | nmap_chunked "$OUT/services/smb_info.txt" -Pn -n --script "smb2-security-mode,smb2-time,smb-os-discovery,smb2-capabilities" -p445 || true
 fi


### PR DESCRIPTION
## Summary
- Expand SMB nmap check messaging to include smb2-time and smb2-capabilities.
- Ensure nmap script list is consolidated on a single line.

## Testing
- `tests/test_mask2prefix.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9a0abb33883288641fad7abbc6ee0