### PR TITLE
Add ticketing stub and documentation

### DIFF
--- a/docs/manual_ticketing.md
+++ b/docs/manual_ticketing.md
@@ -1,0 +1,12 @@
+# External Ticketing Follow-Up
+
+The pipeline can generate ticket stubs for findings, but external tracking systems
+still require manual entry. After the run is approved:
+
+1. Review the generated stub in `out/tickets/` (e.g., `ticket_<timestamp>.md`).
+2. In your organization's external system (Jira, ServiceNow, etc.), create a new ticket.
+3. Copy the contents of the stub into the ticket description.
+4. Attach any relevant evidence from the `out/` and `evidence/` directories.
+5. Assign the ticket to the appropriate team and track the external ticket ID for follow-up.
+
+These steps ensure findings are properly tracked beyond the internal pipeline.

--- a/jobs/95_ticketing_stub.sh
+++ b/jobs/95_ticketing_stub.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Compile approved findings into a ticket stub for external systems.
+# The resulting markdown file can be copied into Jira, ServiceNow, etc.
+set -Eeuo pipefail
+
+OUT="${1:-$HOME/out}"
+RUNID="$(date +%Y%m%d_%H%M%S)"
+TICKET_DIR="$OUT/tickets"
+TICKET_FILE="$TICKET_DIR/ticket_${RUNID}.md"
+
+mkdir -p "$TICKET_DIR"
+
+REPORT="$(ls -1t "$OUT"/report_*.md 2>/dev/null | head -n1 || true)"
+{
+  echo "# Ticket Stub for Findings ($RUNID)"
+  echo
+  if [[ -n "$REPORT" && -s "$REPORT" ]]; then
+    echo "_Source report: $(basename "$REPORT")_"
+    echo
+    awk '/## High-Signal Findings/{flag=1;next}/^##/{flag=0}flag' "$REPORT" 2>/dev/null \
+      | sed '/^[[:space:]]*$/d'
+  else
+    echo "*No report found to extract findings.*"
+  fi
+  echo
+  echo "> After review, manually create a ticket in the external system (e.g., Jira, ServiceNow)."
+  echo "> Attach relevant evidence and assign to the responsible team."
+} > "$TICKET_FILE"
+
+echo "[+] Ticket stub written to $TICKET_FILE"

--- a/run.sh
+++ b/run.sh
@@ -116,6 +116,9 @@ if [[ ! -f "$OUT/APPROVED" ]]; then
   exit 2
 fi
 
+# ---- ticketing stub ----
+run_stage "95_ticketing_stub"      "$BASE/jobs/95_ticketing_stub.sh"     "$OUT"
+
 # ---- archive ----
 echo "[*] Archiving artifacts..."
 mkdir -p "$ARCH/out" "$ARCH/evidence"


### PR DESCRIPTION
## Summary
- add 95_ticketing_stub job to produce ticket Markdown from approved reports
- call ticketing stub after HITL gate in run.sh
- document manual follow-up for external ticketing systems

## Testing
- `tests/test_mask2prefix.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9a0be34e08328a9dbe3ff7628272a