### PR TITLE
Prompt for ticketing approval

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -111,8 +111,15 @@ run_stage "06_vulns_nuclei"        "$BASE/jobs/06_vulns_nuclei.sh"       "$OUT"
 run_stage "90_reduce_and_report"   "$BASE/jobs/90_reduce_and_report.sh"  "$OUT" "$EVID"
 
 # ---- HITL gate ----
-if [[ ! -f "$OUT/APPROVED" ]]; then
-  echo "[!] Waiting for HITL approval in $OUT. Touch $OUT/APPROVED to continue."
+if [[ -t 0 ]]; then
+  read -rp "Proceed to ticketing? [y/N] " _ans || {
+    echo "[!] No input received." >&2; exit 2; }
+  if [[ ! $_ans =~ ^[Yy] ]]; then
+    echo "[!] Aborting without ticketing." >&2
+    exit 2
+  fi
+else
+  echo "[!] Waiting for HITL approval in $OUT. Touch $OUT/APPROVED to continue." >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary
- Replace file-based HITL gate with interactive yes/no prompt
- Abort unless response begins with `y`/`Y`
- Retain guidance when no TTY is available

## Testing
- `tests/test_mask2prefix.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9a0c031ac8328bb8aeb7bf762ce11