### PR TITLE
Add vulnerability summary parsing to report

### DIFF
--- a/jobs/90_reduce_and_report.sh
+++ b/jobs/90_reduce_and_report.sh
@@ -33,6 +33,16 @@ mkdir -p "$OUT" "$EVID"
   else
     echo "- No nuclei findings (file missing or jq not installed)."
   fi
+  # Vulnerability summary findings (jsonl)
+  if [[ -s "$OUT/vulns_summary.jsonl" ]] && command -v jq >/dev/null 2>&1; then
+    echo
+    echo "### Vulnerability Summary"
+    jq -r '
+      "- \(.host) \(.port)/\(.service) [\(.severity)] - \(.remediation)"
+    ' "$OUT/vulns_summary.jsonl" 2>/dev/null || true
+  else
+    echo "- No vulnerability summary findings (file missing or jq not installed)."
+  fi
   # TLS notes (best-effort grep)
   if [[ -s "$OUT/testssl.txt" ]]; then
     echo


### PR DESCRIPTION
## Summary
- Parse `vulns_summary.jsonl` in the final report job and list each finding with host, port/service, severity, and remediation.

## Testing
- `bash tests/test_mask2prefix.sh`
- `bash <(tr -d '\r' < jobs/90_reduce_and_report.sh) /tmp/out /tmp/evid`


------
https://chatgpt.com/codex/tasks/task_e_68b9a0c5c8348328b4be527d127fcb16