### PR TITLE
Aggregate vulnerability summary across scan outputs

### DIFF
--- a/jobs/06_vulns_nuclei.sh
+++ b/jobs/06_vulns_nuclei.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 source "$(dirname "$0")/../config/config.env"
+source "$(dirname "$0")/../lib/vuln_summary.sh"
 OUT="${1:-$HOME/out}"
+SUMMARY="$OUT/vulns_summary.jsonl"
+# Ensure summary file exists but do not overwrite existing service-check data
+touch "$SUMMARY"
 [[ -s "$OUT/urls.live" ]] || exit 0
 echo "[*] nuclei (curated)"
 nuclei -update-templates >/dev/null 2>&1 || true
@@ -9,3 +13,18 @@ nuclei -list "$OUT/urls.live" \
   -severity "$NUCLEI_SEVERITY" \
   -tags "$NUCLEI_TAGS" \
   -jsonl -o "$OUT/nuclei.jsonl" || true
+# Summarize nuclei findings
+if [[ -s "$OUT/nuclei.jsonl" ]] && command -v jq >/dev/null 2>&1; then
+  jq -c '{host:(.host // (.matched-at | sub("https?://"; "") | split("/")[0])), service:(.type // "http"), severity:.info.severity, description:.info.name}' "$OUT/nuclei.jsonl" >> "$SUMMARY" || true
+fi
+# Summarize TLS/testssl findings
+if [[ -s "$OUT/testssl.txt" ]]; then
+  current_host=""
+  while IFS= read -r line; do
+    if [[ $line =~ ^Testing[[:space:]]+([0-9A-Za-z:\.-]+) ]]; then
+      current_host="${BASH_REMATCH[1]}"
+    elif echo "$line" | grep -qiE 'vulnerable|expired|not ok|weak'; then
+      add_vuln "$SUMMARY" "$current_host" "tls" "medium" "$line"
+    fi
+  done < "$OUT/testssl.txt"
+fi

--- a/jobs/07_service_checks.sh
+++ b/jobs/07_service_checks.sh
@@ -3,6 +3,9 @@
 set -Eeuo pipefail
 OUT="${1:-$HOME/out}"
 mkdir -p "$OUT/services"
+source "$(dirname "$0")/../lib/vuln_summary.sh"
+SUMMARY="$OUT/vulns_summary.jsonl"
+touch "$SUMMARY"
 OPEN_PORTS="$OUT/open.ports"
 # If no open ports, nothing to do
 [[ -s "$OPEN_PORTS" ]] || { echo "[i] $OPEN_PORTS missing/empty; skipping service checks."; exit 0; }
@@ -148,6 +151,27 @@ if [[ -n "$SNMP_HOSTS" && -s "$OUT/snmp_communities.txt" && $(have snmpwalk && e
         >> "$OUT/services/snmp_sysdescr.txt" 2>/dev/null || true
     done < "$OUT/snmp_communities.txt"
   done <<< "$SNMP_HOSTS"
+fi
+# Summarize service findings into JSONL
+if [[ -d "$OUT/services" ]]; then
+  find "$OUT/services" -type f -name "*.txt" | while read -r file; do
+    svc=$(basename "$(dirname "$file")")
+    if [[ "$svc" == "services" ]]; then
+      svc=$(basename "$file" .txt)
+    fi
+    if [[ "$svc" == "ssh" ]]; then
+      host=$(basename "$file" .txt)
+      grep -Ei 'warning|fail|weak|CVE|VULNERABLE|error|anonymous' "$file" | while read -r line; do
+        add_vuln "$SUMMARY" "$host" "$svc" "info" "$line"
+      done
+    else
+      grep -Ei 'vulnerable|weak|anonymous|error' "$file" | while read -r line; do
+        host=$(echo "$line" | awk '{print $1}')
+        [[ "$host" =~ ^[0-9] ]] || continue
+        add_vuln "$SUMMARY" "$host" "$svc" "info" "$line"
+      done
+    fi
+  done
 fi
 echo "[+] Service checks complete."
 

--- a/jobs/90_reduce_and_report.sh
+++ b/jobs/90_reduce_and_report.sh
@@ -40,6 +40,15 @@ mkdir -p "$OUT" "$EVID"
     grep -Ei "certificate|expired|TLSv1[^.2]|weak|insecure|vulnerable" "$OUT/testssl.txt" 2>/dev/null \
       | head -n 50 | sed 's/^/- /' || true
   fi
+  # Aggregated summary of high severity findings
+  if [[ -s "$OUT/vulns_summary.jsonl" ]] && command -v jq >/dev/null 2>&1; then
+    echo
+    echo "### Aggregated Findings"
+    jq -r '
+      select(.severity=="critical" or .severity=="high")
+      | "- " + .host + " (" + .service + ") â€” " + .description + " [" + .severity + "]"
+    ' "$OUT/vulns_summary.jsonl" 2>/dev/null || true
+  fi
   # Service checks summary
   if [[ -d "$OUT/services" ]]; then
     echo "" >> "$REPORT"

--- a/lib/vuln_summary.sh
+++ b/lib/vuln_summary.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Helper to append vulnerability entries in JSONL format
+# Usage: add_vuln <file> <host> <service> <severity> <description>
+add_vuln() {
+  local _file="$1"; shift
+  local _host="$1"; shift
+  local _service="$1"; shift
+  local _severity="$1"; shift
+  local _desc="$*"
+  _desc=${_desc//"/\"}
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg h "$_host" --arg s "$_service" --arg sev "$_severity" --arg d "$_desc" \
+      '{host:$h, service:$s, severity:$sev, description:$d}' >> "$_file"
+  else
+    printf '{"host":"%s","service":"%s","severity":"%s","description":"%s"}\n' \
+      "$_host" "$_service" "$_severity" "$_desc" >> "$_file"
+  fi
+}


### PR DESCRIPTION
## Summary
- Parse nuclei and TLS results into new `vulns_summary.jsonl`
- Append service check findings to the consolidated summary
- Report high-severity items from the summary in `90_reduce_and_report.sh`
- Preserve service-check entries when the nuclei stage runs and allow adding vulnerabilities without `jq`

## Testing
- `bash tests/test_mask2prefix.sh`
- `apt-get install -y shellcheck` *(fails: Unable to locate package)*
- `shellcheck jobs/06_vulns_nuclei.sh jobs/07_service_checks.sh jobs/90_reduce_and_report.sh lib/vuln_summary.sh` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a0cd8cd48328a096cabcc181a3fb