### PR TITLE
Aggregate high severity vulnerabilities in report

### DIFF
--- a/jobs/90_reduce_and_report.sh
+++ b/jobs/90_reduce_and_report.sh
@@ -33,12 +33,13 @@ mkdir -p "$OUT" "$EVID"
   else
     echo "- No nuclei findings (file missing or jq not installed)."
   fi
-  # Vulnerability summary findings (jsonl)
+  # Aggregated high severity vulnerability findings (jsonl)
   if [[ -s "$OUT/vulns_summary.jsonl" ]] && command -v jq >/dev/null 2>&1; then
     echo
-    echo "### Vulnerability Summary"
+    echo "### Aggregated Findings"
     jq -r '
-      "- \(.host) \(.port)/\(.service) [\(.severity)] - \(.remediation)"
+      select(.severity=="critical" or .severity=="high")
+      | "- \(.host) \(.port)/\(.service) [\(.severity)] - \(.remediation)"
     ' "$OUT/vulns_summary.jsonl" 2>/dev/null || true
   else
     echo "- No vulnerability summary findings (file missing or jq not installed)."


### PR DESCRIPTION
## Summary
- Consolidate `vulns_summary.jsonl` reporting into a high-severity **Aggregated Findings** section.
- Leave existing TLS quick observations and service enumeration highlights after the vulnerability summary block.

## Testing
- `bash -n jobs/90_reduce_and_report.sh` *(fails: syntax error near unexpected token `elif`)*
- `tests/test_mask2prefix.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9a50f62088328a0b2642e0ba34213