### PR TITLE
Surface service-level vulnerabilities in reports and ticketing

### DIFF
--- a/jobs/08_vulns_summary.sh
+++ b/jobs/08_vulns_summary.sh
@@ -2,20 +2,30 @@
 set -Eeuo pipefail
 OUT="${1:-$HOME/out}"
 
-# require nuclei results and jq for parsing
-if [[ ! -s "$OUT/nuclei.jsonl" ]] || ! command -v jq >/dev/null 2>&1; then
-  exit 0
+# require jq for parsing
+command -v jq >/dev/null 2>&1 || exit 0
+
+SUMMARY="$OUT/vulns_summary.jsonl"
+: > "$SUMMARY"
+
+# Extract high/critical nuclei results if present
+if [[ -s "$OUT/nuclei.jsonl" ]]; then
+  jq -r '
+    select(.info.severity=="critical" or .info.severity=="high") |
+    {
+      host: (.host | sub("^https?://"; "") | split("/")[0] | split(":")[0]),
+      port: ((.host | sub("^https?://"; "") | split("/")[0] | split(":")[1]) // ""),
+      service: (.type // "nuclei"),
+      severity: .info.severity,
+      remediation: .info.name
+    } | @json
+  ' "$OUT/nuclei.jsonl" >> "$SUMMARY" 2>/dev/null || true
 fi
 
-# Extract high/critical vulnerabilities into a normalized summary
-# Fields: host, port, service, severity, remediation
-jq -r '
-  select(.info.severity=="critical" or .info.severity=="high") |
-  {
-    host: (.host | sub("^https?://"; "") | split("/")[0] | split(":")[0]),
-    port: ((.host | sub("^https?://"; "") | split("/")[0] | split(":")[1]) // ""),
-    service: (.type // "nuclei"),
-    severity: .info.severity,
-    remediation: .info.name
-  } | @json
-' "$OUT/nuclei.jsonl" > "$OUT/vulns_summary.jsonl" 2>/dev/null || true
+# Append service vulnerabilities if present
+if [[ -s "$OUT/services_vulns.jsonl" ]]; then
+  cat "$OUT/services_vulns.jsonl" >> "$SUMMARY"
+fi
+
+# Remove file if no findings
+[[ -s "$SUMMARY" ]] || rm -f "$SUMMARY"

--- a/jobs/90_reduce_and_report.sh
+++ b/jobs/90_reduce_and_report.sh
@@ -33,7 +33,7 @@ mkdir -p "$OUT" "$EVID"
   else
     echo "- No nuclei findings (file missing or jq not installed)."
   fi
-  # Aggregated high severity vulnerability findings (jsonl)
+  # Aggregated high severity vulnerability findings (web & service)
   if [[ -s "$OUT/vulns_summary.jsonl" ]] && command -v jq >/dev/null 2>&1; then
     echo
     echo "### Aggregated Findings"
@@ -59,22 +59,11 @@ mkdir -p "$OUT" "$EVID"
       | head -n 50 | sed 's/^/- /' || true
   fi
   # Service checks summary
-  if [[ -d "$OUT/services" ]]; then
+  if [[ -s "$OUT/services_vulns.jsonl" ]] && command -v jq >/dev/null 2>&1; then
     echo "" >> "$REPORT"
     echo "## Service Enumeration Highlights" >> "$REPORT"
-    [[ -s "$OUT/services/ssh/"* ]] && echo "- SSH audits: $(ls "$OUT/services/ssh" 2>/dev/null | wc -l) hosts" >> "$REPORT"
-    [[ -s "$OUT/services/rdp_enum.txt" ]] && echo "- RDP encryption info collected." >> "$REPORT"
-    [[ -s "$OUT/services/smb_info.txt" ]] && echo "- SMB info & security mode enumerated." >> "$REPORT"
-    [[ -s "$OUT/services/ldap_search.txt" ]] && echo "- LDAP anonymous search attempted." >> "$REPORT"
-    [[ -s "$OUT/services/winrm_auth.txt" ]] && echo "- WinRM auth methods checked." >> "$REPORT"
-    [[ -s "$OUT/services/mssql_info.txt" ]] && echo "- MSSQL info gathered." >> "$REPORT"
-    [[ -s "$OUT/services/mysql_info.txt" ]] && echo "- MySQL info/empty-password checks." >> "$REPORT"
-    [[ -s "$OUT/services/pgsql_info.txt" ]] && echo "- PostgreSQL version info." >> "$REPORT"
-    [[ -s "$OUT/services/redis_info.txt" ]] && echo "- Redis info (auth exposure) checked." >> "$REPORT"
-    [[ -s "$OUT/services/vnc_info.txt" ]] && echo "- VNC info gathered." >> "$REPORT"
-    [[ -s "$OUT/services/dns_recursion.txt" ]] && echo "- DNS recursion tested." >> "$REPORT"
-    [[ -s "$OUT/services/nfs_showmount.txt" ]] && echo "- NFS exports enumerated." >> "$REPORT"
-    [[ -s "$OUT/services/snmp_sysdescr.txt" ]] && echo "- SNMP sysDescr gathered (approved communities)." >> "$REPORT"
+    jq -r '"- \(.host) \(.port)/\(.service) [\(.severity)] - \(.remediation)"' \
+      "$OUT/services_vulns.jsonl" 2>/dev/null >> "$REPORT"
   fi
   # Screenshots
   if [[ -d "$EVID/screens" ]]; then

--- a/jobs/95_ticketing_stub.sh
+++ b/jobs/95_ticketing_stub.sh
@@ -15,10 +15,16 @@ REPORT="$(ls -1t "$OUT"/report_*.md 2>/dev/null | head -n1 || true)"
   echo "# Ticket Stub for Findings ($RUNID)"
   echo
   if [[ -n "$REPORT" && -s "$REPORT" ]]; then
-    echo "_Source report: $(basename "$REPORT")_"
+    echo "_Source report: $(basename \"$REPORT\")_"
     echo
-    awk '/## High-Signal Findings/{flag=1;next}/^##/{flag=0}flag' "$REPORT" 2>/dev/null \
+    awk '/## High-Signal Findings/{flag=1;next}/^##/{if(flag)exit}flag' "$REPORT" 2>/dev/null \
       | sed '/^[[:space:]]*$/d'
+    if grep -q "## Service Enumeration Highlights" "$REPORT" 2>/dev/null; then
+      echo
+      echo "## Service Enumeration Highlights"
+      awk '/## Service Enumeration Highlights/{flag=1;next}/^##/{if(flag)exit}flag' "$REPORT" 2>/dev/null \
+        | sed '/^[[:space:]]*$/d'
+    fi
   else
     echo "*No report found to extract findings.*"
   fi


### PR DESCRIPTION
## Summary
- parse service enumeration outputs to flag insecure configs and store as JSONL
- merge service findings with Nuclei results for a unified vulnerability summary
- expose service-level vulnerabilities in reports and ticket stubs

## Testing
- `bash -n jobs/07_service_checks.sh`
- `bash -n jobs/08_vulns_summary.sh`
- `bash -n jobs/90_reduce_and_report.sh`
- `bash -n jobs/95_ticketing_stub.sh`
- `tests/test_mask2prefix.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b9ab7c440083289464948b822e3826