### PR TITLE
chore: point run script to casm

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Internal ASM orchestrator (robust)
+# CASM orchestrator (robust)
 set -Eeo pipefail
 
-BASE="$HOME/internal-asm"
+BASE="$HOME/casm"
 CONF="$BASE/config/config.env"
 
 OUT_ROOT="$HOME/out"         # Windows-backed


### PR DESCRIPTION
## Summary
- update run.sh to use $HOME/casm as base directory
- revise header comment to CASM orchestrator

## Testing
- `bash tests/test_mask2prefix.sh`
- `rg -i internal-asm`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9ad08748328847ee1b2fd32b9dd